### PR TITLE
remove a 0 at the end of the tree alias

### DIFF
--- a/exa-zsh.plugin.zsh
+++ b/exa-zsh.plugin.zsh
@@ -16,5 +16,5 @@ alias ll='ls -la' # long, all
 alias llm='ll --sort=modified' # list, long, sort by modification date
 alias la='ls -lbhHigUmuSa' # all list
 alias lx='ls -lbhHigUmuSa@' # all list and extended
-alias tree='exa --tree'0 # tree view
+alias tree='exa --tree' # tree view
 alias lS='exa -1' # one column by just names


### PR DESCRIPTION
Hi,
There was a 0 at the end of the "tree" alias, after the ending quote.
It was breaking the use of this alias.